### PR TITLE
分页功能bug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ permalink: /:year/:month/:day/:title/
 
 # Build settings
 markdown: kramdown
+gems: [jekyll-paginate]
 
 paginate: 10
 paginate_path: "page:num"


### PR DESCRIPTION
config.yml 增加代码 `gems: [jekyll-paginate]`
- 解决的问题：博客首页不分页，而且所有博文的列表无法显示（刷新时一闪烁就隐藏了）
- 运行时报错：
_Deprecation: You appear to have pagination turned on, but you haven't inc
luded the `jekyll-paginate` gem. Ensure you have `gems: [jekyll-paginate]` in yo
ur configuration file._