### PR TITLE
fix the issue: in first post page, div tag isn't closed

### DIFF
--- a/_includes/previousAndNext.html
+++ b/_includes/previousAndNext.html
@@ -1,7 +1,6 @@
 <div class="post-recent">
-    {% if page.previous %}
     <div class="pre">
-
+        {% if page.previous %}
         <p><strong>上一篇</strong> <a href="{{ page.previous.url | prepend: site.baseurl }}">{{ page.previous.title }}</a></p>
         {% endif %}
     </div>


### PR DESCRIPTION
第一个post，由于page.previous为null，原来的代码会导致div没有close（div的开tag在if块内，但是div的闭tag在if块外），这个pull request调换了第一行（if）和第二行（div）的位置，解决该问题。

    {% if page.previous %}
    <div class="pre">

        <p><strong>上一篇</strong> <a href="{{ page.previous.url | prepend: site.baseurl }}">{{ page.previous.title }}</a></p>
        {% endif %}
    </div>