### PR TITLE
add support for mathjax

### DIFF
--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -236,7 +236,7 @@ google_analytics_id: UA-72449510-4 # google 分析追踪id
 
 ### 4. 写文章
 
-`_posts`目录下存放文章信息，文章头部注明 layout(布局)、title、date、categories、tags、author(可选)，如下：
+`_posts`目录下存放文章信息，文章头部注明 layout(布局)、title、date、categories、tags、author(可选)、mathjax(可选，点击[这里](https://www.mathjax.org/)查看更多关于`Mathjax`)，如下：
 
 ```
 ---
@@ -246,6 +246,7 @@ date:   2016-03-12 11:40:18 +0800
 categories: jekyll
 tags: jekyll 端口 markdown Foxit RubyGems HTML CSS
 author: Haoyang Gao
+mathjax: true
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ When you done, you can see UV, PV, location etc. info at your own Google Analyti
 
 ### 4. Write post
 
-You can write posts at folder `_posts`. At the beginning of the post, you should declare layout、title、date、categories、tags、author(optional) info.
+You can write posts at folder `_posts`. At the beginning of the post, you should declare layout、title、date、categories、tags、author(optional) info、mathjax(optional，click [here](https://www.mathjax.org/) for more detail about `Mathjax`).
 
 ```
 ---
@@ -247,6 +247,7 @@ date:   2016-03-12 11:40:18 +0800
 categories: jekyll
 tags: jekyll 端口 markdown Foxit RubyGems HTML CSS
 author: Haoyang Gao
+mathjax: true
 ---
 ```
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,4 +39,18 @@
 
     </script>
 {% endif %}
+
+{% if page.mathjax %}
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+    tex2jax: { inlineMath: [["$","$"],["\\(","\\)"]] },
+    "HTML-CSS": {
+      linebreaks: { automatic: true, width: "container" }
+    }
+});
+</script>
+<script type="text/javascript"
+  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+{% endif %}
 </head>

--- a/_posts/2015-02-10-welcome-to-jekyll.markdown
+++ b/_posts/2015-02-10-welcome-to-jekyll.markdown
@@ -5,6 +5,7 @@ date:   2015-02-10 15:14:54
 categories: jekyll
 tags: jekyll
 excerpt: 当年创建 jekyll 时默认的一篇文章，没什么意义，我也一直没删除，留个纪念吧。
+mathjax: true
 ---
 
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
@@ -26,3 +27,12 @@ Check out the [Jekyll docs][jekyll] for more info on how to get the most out of 
 [jekyll]:      http://jekyllrb.com
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-help]: https://github.com/jekyll/jekyll-help
+
+Block Mathjax 
+
+$$
+f(x) = ax + b
+$$
+
+Inline Mathjax $a \neq b$
+


### PR DESCRIPTION
Add support for [Mathjax](https://www.mathjax.org/), which should be very useful for writing algorithm's time complexity or other kind of mathematical formulas in this markdown based blog.    
Sample is provided in your first post.