### PR TITLE
similar posts and cdn of mathjax

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -50,7 +50,7 @@
 });
 </script>
 <script type="text/javascript"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 {% endif %}
 </head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -79,7 +79,9 @@ layout: default
                     Content
                 </div>
                 <ul id="content-side" class="content-ul">
+                    {% if hasSimilar.size > 0 %}
                     <li><a href="#similar_posts">Similar Posts</a></li>
+                    {% endif %}
                     <li><a href="#comments">Comments</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
1. the original cdn of mathjax is shut down. I change it to the recommended one.
2. fix bug: show "similar posts" in side content even when there are no similar posts actually