### PR TITLE
Avoid deprecation :warning:

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,5 +56,5 @@ tag_dir: tag/
 excerpt_separator: "\n\n\n\n"
 
 # paginate
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 paginate: 6


### PR DESCRIPTION
`gems` config key has been defaulted to `plugins` since Jekyll 3.5, this PR intend to avoid the following deprecation warning at build time:

```
 Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```