### PR TITLE
The 'gems' configuration option has been renamed to 'plugins'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,5 +56,5 @@ tag_dir: tag/
 excerpt_separator: "\n\n\n\n"
 
 # paginate
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 paginate: 6


### PR DESCRIPTION
As of Jekyll `v3.5.0`, the `gems` configuration key has been renamed to `plugins`.

https://jekyllrb.com/news/2017/06/15/jekyll-3-5-0-released/